### PR TITLE
Stipendiat im Bereich Jakarta EE: Jeremias Weber

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Zukünftig steht das Förderprogramm auch weiteren Projekten offen und werden di
 
 ## Stipendiaten
 
-Aktuell haben wir uns noch nicht für einen bestimmten Stipendiaten entschieden. Bitte bewerbe Dich über stipendium at ijug punkt eu für ein Stipendium! Neben der Erreichung des aktuellen Förderziels (Du wirst als Committer in einem der genannten Projekte vorgeschlagen) winkt Dir wertvolle, persönliche Beratung durch erfahrene Mentoren aus den jeweiligen Projekten, sowie die von den Sponsoren (s. u.) gewährten Vorteile. Zum Stipendium berechtigt sind derzeit alle Personen, die mehrfach Contributions zu einem der genannten Projekte beigesteuert haben. Zum Nachweis genügen uns die Links zu drei Commits, die Du beigesteuert hast. Das Stipendium ist für einen Zeitraum von einem Jahr ausgelegt und wir erwarten, dass Du ernsthaft (mehrere Stunden in der Woche) an dem Projekt mitarbeitest und den Ratschläge der Mentoren folgst.
+Aktuell haben wir uns noch nicht für einen bestimmten Stipendiaten in jedem von uns geförderten Bereich entschieden. Bitte bewerbe Dich über stipendium at ijug punkt eu für ein Stipendium! Neben der Erreichung des aktuellen Förderziels (Du wirst als Committer in einem der genannten Projekte vorgeschlagen) winkt Dir wertvolle, persönliche Beratung durch erfahrene Mentoren aus den jeweiligen Projekten, sowie die von den Sponsoren (s. u.) gewährten Vorteile. Zum Stipendium berechtigt sind derzeit alle Personen, die mehrfach Contributions zu einem der genannten Projekte beigesteuert haben. Zum Nachweis genügen uns die Links zu drei Commits, die Du beigesteuert hast. Das Stipendium ist für einen Zeitraum von einem Jahr ausgelegt und wir erwarten, dass Du ernsthaft (mehrere Stunden in der Woche) an dem Projekt mitarbeitest und den Ratschläge der Mentoren folgst.
+
+* Jakarta EE: Jeremias Weber (@jelemux) (Mentor: Markus Karg)
+* Adoptium: (offen)
+* Microprofile: (offen)
 
 
 ## Mentoren


### PR DESCRIPTION
Als Mentor für Jakarta EE habe ich mich heute final für den Bewerber Jeremias Weber entschieden, den ich als Mentor bereits seit einiger Zeit betreue. Jeremias hat sich mit mehreren Contributions zu JAX-RS bzw. dem JAX-RS-TCK nominiert und arbeitet derzeit daran, Committer für JAX-RS und ggf. Eclipse Krazo zu werden.